### PR TITLE
Revert build.dir change in build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2,7 +2,7 @@
 
 	<property environment="env" />
 
-	<property name="build.dir" value="${basedir}/build" />
+	<property name="build.dir" value="build" />
 	<property name="classes.dir" value="${build.dir}/packaging" />
 	<property name="apiclasses.dir" value="${build.dir}/api-packaging" />
 	<property name="src.dir" value="src" />


### PR DESCRIPTION
It breaks patch.py if the path has spaces. I'll edit it myself locally
when need be.
