### PR TITLE
Fix drinking mob essence

### DIFF
--- a/src/powercrystals/minefactoryreloaded/modhelpers/vanilla/Vanilla.java
+++ b/src/powercrystals/minefactoryreloaded/modhelpers/vanilla/Vanilla.java
@@ -283,7 +283,7 @@ public class Vanilla
 		MFRRegistry.registerLiquidDrinkHandler("bioethanol", new DrinkHandlerBiofuel());
 		MFRRegistry.registerLiquidDrinkHandler("sewage", new DrinkHandlerSewage());
 		MFRRegistry.registerLiquidDrinkHandler("sludge", new DrinkHandlerSludge());
-		MFRRegistry.registerLiquidDrinkHandler("essence", new DrinkHandlerMobEssence());
+		MFRRegistry.registerLiquidDrinkHandler("mobessence", new DrinkHandlerMobEssence());
 		MFRRegistry.registerLiquidDrinkHandler("meat", new DrinkHandlerMeat());
 		MFRRegistry.registerLiquidDrinkHandler("pinkslime", new DrinkHandlerPinkSlime());
 		MFRRegistry.registerLiquidDrinkHandler("chocolatemilk", new DrinkHandlerChocolateMilk());


### PR DESCRIPTION
Currently you can't drink mob essence through a straw, because the drink handler is still registered with the old name "essence". This change makes drinking mob essence work again.
