### PR TITLE
Added OpenBlocks XPJuice to Unifier

### DIFF
--- a/src/powercrystals/minefactoryreloaded/tile/machine/TileEntityUnifier.java
+++ b/src/powercrystals/minefactoryreloaded/tile/machine/TileEntityUnifier.java
@@ -33,6 +33,7 @@ public class TileEntityUnifier extends TileEntityFactoryInventory implements ITa
 	private static FluidStack _ethanol;
 	private static FluidStack _essence;
 	private static FluidStack _liquidxp;
+	private static FluidStack _xpjuice;
 	private int _roundingCompensation;
 	private boolean ignoreChange = false;
 	
@@ -51,6 +52,7 @@ public class TileEntityUnifier extends TileEntityFactoryInventory implements ITa
 		_ethanol = FluidRegistry.getFluidStack("bioethanol", 1);
 		_essence = FluidRegistry.getFluidStack("mobessence", 1);
 		_liquidxp = FluidRegistry.getFluidStack("immibis.liquidxp", 1);
+		_xpjuice = FluidRegistry.getFluidStack("xpjuice", 1);
 	}
 	
 	@Override
@@ -264,7 +266,7 @@ public class TileEntityUnifier extends TileEntityFactoryInventory implements ITa
 			else if (_biofuel.isFluidEqual(resource))
 				return new FluidStack(_ethanol.fluidID, resource.amount);
 		}
-		if(_essence != null & _liquidxp != null)
+		if(_essence != null & _liquidxp != null &_xpjuice == null)
 		{
 			if (_liquidxp.isFluidEqual(resource))
 				return new FluidStack(_essence.fluidID, resource.amount * 2);
@@ -275,6 +277,32 @@ public class TileEntityUnifier extends TileEntityFactoryInventory implements ITa
 						resource.amount / 2 + (resource.amount & _roundingCompensation));
 			}
 		}
+		if(_essence != null & _liquidxp == null & _xpjuice != null)
+		{
+			if (_xpjuice.isFluidEqual(resource))
+				return new FluidStack(_essence.fluidID, resource.amount * 2);
+				//_xpjuice / _essence ratio based off of _liquidxp / _essence ratio
+			else if (_essence.isFluidEqual(resource))
+			{
+				if(doFill) _roundingCompensation ^= (resource.amount & 1);
+				return new FluidStack(_xpjuice.fluidID, 
+						resource.amount / 2 + (resource.amount & _roundingCompensation));
+			}
+		}
+		if(_essence != null & _liquidxp != null & _xpjuice != null)
+		{
+			if (_liquidxp.isFluidEqual(resource))
+				return new FluidStack(_xpjuice.fluidID, resource.amount);
+			else if (_xpjuice.isFluidEqual(resource))
+				return new FluidStack(_essence.fluidID, resource.amount * 2));
+			else if (_essence.isFluidEqual(resource))
+			{
+				if(doFill) _roundingCompensation ^= (resource.amount & 1);
+				return new FluidStack(_liquidxp.fluidID, 
+						resource.amount / 2 + (resource.amount & _roundingCompensation));
+			}
+		}
+		//Fluids loop around as to not conflict if both mods are installed
 		return null;
 	}
 	


### PR DESCRIPTION
Added OpenBlocks XPJuice to Unifier in a way that allows the fluids to loop (LiquidXP > XPJuice > Essence > LiquidXP...) if both compatible mods are installed (and just like LiquidXP if only OpenBlocks is installed).
