### PR TITLE
Fix dupe with Thaumcraft Pechs

### DIFF
--- a/src/powercrystals/minefactoryreloaded/modhelpers/thaumcraft/SpawnablePech.java
+++ b/src/powercrystals/minefactoryreloaded/modhelpers/thaumcraft/SpawnablePech.java
@@ -1,0 +1,46 @@
+package powercrystals.minefactoryreloaded.modhelpers.thaumcraft;
+
+import java.lang.reflect.Field;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+
+import powercrystals.minefactoryreloaded.api.IMobSpawnHandler;
+
+public class SpawnablePech implements IMobSpawnHandler
+{
+	private Class<? extends EntityLivingBase> _tcPechClass;
+	private Field _tcPechLootField;
+	
+	public SpawnablePech(Class<?> pech)
+	{
+		_tcPechClass = (Class<? extends EntityLivingBase>) pech;
+	}
+	
+	@Override
+	public Class<? extends EntityLivingBase> getMobClass()
+	{
+		return _tcPechClass;
+	}
+
+	@Override
+	public void onMobSpawn(EntityLivingBase entity) {}
+
+	@Override
+	public void onMobExactSpawn(EntityLivingBase entity)
+	{
+		try
+		{
+			if (_tcPechLootField == null)
+			{
+				_tcPechLootField = _tcPechClass.getDeclaredField("loot");
+			}
+			_tcPechLootField.set(entity, new ItemStack[9]);
+		}
+		catch (Throwable e)
+		{
+			e.printStackTrace();
+			entity.setDead();
+		}
+	}
+}

--- a/src/powercrystals/minefactoryreloaded/modhelpers/thaumcraft/Thaumcraft.java
+++ b/src/powercrystals/minefactoryreloaded/modhelpers/thaumcraft/Thaumcraft.java
@@ -56,9 +56,12 @@ public class Thaumcraft
 			final Item tcBean = GameRegistry.findItem("Thaumcraft", "ItemManaBean");
 			Class<?> golem = Class.forName("thaumcraft.common.entities.golems.EntityGolemBase");
 			Class<?> trunk = Class.forName("thaumcraft.common.entities.golems.EntityTravelingTrunk");
+			Class<?> pech = Class.forName("thaumcraft.common.entities.monster.EntityPech");
 			
 			MFRRegistry.registerAutoSpawnerBlacklistClass(golem);
 			MFRRegistry.registerAutoSpawnerBlacklistClass(trunk);
+			
+			MFRRegistry.registerSpawnHandler(new SpawnablePech(pech));
 			
 			MFRRegistry.registerGrinderBlacklist(golem);
 			MFRRegistry.registerGrinderBlacklist(trunk);


### PR DESCRIPTION
Items picked up by pechs will be duplicated if exact spawn is on on an autospawner.
