### PR TITLE
Update Vanilla.java to allow nether ore generation

### DIFF
--- a/src/powercrystals/minefactoryreloaded/modhelpers/vanilla/Vanilla.java
+++ b/src/powercrystals/minefactoryreloaded/modhelpers/vanilla/Vanilla.java
@@ -500,8 +500,8 @@ public class Vanilla
 				}
 				return;
 			}
-		if (netherName != null & dustName != null)
-			for (ItemStack ore : OreDictionary.getOres(dustName))
+		if (netherName != null )
+			for (ItemStack ore : OreDictionary.getOres(netherName))
 				if (ore != null)
 				{
 					registerOreDictLaserOre(weight / 2, netherName, netherFocus, null, null);


### PR DESCRIPTION
In Agrarian Skies, for instance, oreNetherIridium is a valid ore to generate, but there are no mods that add a valid dust item.  This change allows the laser drill to pull ores if they are valid according to the ore dictionary, not if they are valid if and only if they have a dust associated with them.

Care must be taken to explicitly disable ores through NetherOres that shouldn't appear here.  If they are in the Ore Dictionary they will be added to the list.
