### PR TITLE
Add tcon compat to mcmod.info

### DIFF
--- a/resources/mcmod.info
+++ b/resources/mcmod.info
@@ -421,5 +421,22 @@
             "MineFactoryReloaded"
         ],
         "description": "Compatibility addon for Forestry Trees"
+    },
+    {
+        "name": "MFR Compat: Tinkers' Construct",
+        "parent": "MineFactoryReloaded",
+        "url": "http://minecraft.curseforge.com/mc-mods/minefactory-reloaded/",
+        "logoFile": "",
+        "updateUrl": "",
+        "credits": "All the contributors",
+        "version": "2.8.0RC6",
+        "modid": "MineFactoryReloaded|CompatTConstruct",
+        "authorList": [ "PowerCrystals" ],
+        "mcversion": "1.7.10",
+        "screenshots": [],
+        "dependencies": [
+            "MineFactoryReloaded"
+        ],
+        "description": "Compatibility addon for Tinkers' Construct"
     }
 ]


### PR DESCRIPTION
Totally insignificant I know, but I noticed it when working on my enhanced mod list GUI, tcon isn't hidden as a child mod because you don't declare a parent for it. So, here we are.