### PR TITLE
Steamboiler: don't produce Steam if the internal Steam-Tank is full.

### DIFF
--- a/src/powercrystals/minefactoryreloaded/tile/machine/TileEntitySteamBoiler.java
+++ b/src/powercrystals/minefactoryreloaded/tile/machine/TileEntitySteamBoiler.java
@@ -143,8 +143,14 @@ public class TileEntitySteamBoiler extends TileEntityFactoryInventory
 
 			if (_temp > 80)
 			{
-				int i = drain(_tanks[1], 100, true);
-				_tanks[0].fill(new FluidStack(_liquidId, i * 4), true);
+				int maxDrain = Math.min(_tanks[0].getSpace(), 400);
+				
+				if ( maxDrain >= 4 ) // as it gets divided by 4, < 4 = 0 (see below)
+				{
+					int i = drain(_tanks[1], (maxDrain / 4), true);
+					_tanks[0].fill(new FluidStack(_liquidId, i * 4), true);
+				}
+				
 			}
 
 			if (skipConsumption || CoreUtils.isRedstonePowered(this))


### PR DESCRIPTION
This changes the behavior of the Steam-Boiler:

###### Old behavior:
Steam being produced all the time, even if the internal steam tank is full.
This implies that water will be consumed, too.

###### New behavior:
If the Steam-Tank is full - it stops steam production,
also no water will be consumed.

Heating / Fuel consumption is not changed - this means that even if there's no steam produced due to full steam tank, fuel gets consumed as it would produce steam.


*If the old behavior was intended as balancing/game-design element - just refuse the PR :)*

