### PR TITLE
Register leaves and logs to additional oredicts

### DIFF
--- a/src/powercrystals/minefactoryreloaded/setup/recipe/Vanilla.java
+++ b/src/powercrystals/minefactoryreloaded/setup/recipe/Vanilla.java
@@ -74,7 +74,9 @@ public class Vanilla {
 		registerOre("itemRubber", rubberBarItem);
 		registerOre("itemRawRubber", rawRubberItem);
 		registerOre("woodRubber", rubberWoodBlock);
+		registerOre("logRubber", rubberWoodBlock);
 		registerOre("leavesRubber", rubberLeavesBlock);
+		registerOre("treeLeavesRubber", rubberLeavesBlock);
 		registerOre("treeSapling", rubberSaplingBlock);
 		registerOre("blockPlastic", factoryPlasticBlock);
 		registerOre("sheetPlastic", plasticSheetItem);


### PR DESCRIPTION
logMaterial and treeLeavesMaterial are the more conventional tag names for logs and leaves. The lack of these entries was causing issues with MFR trees in other mods (namely Flaxbeard's Steam Power).