### PR TITLE
Added check to relightChunk that verifies that the given chunk has skylight data stored

### DIFF
--- a/src/powercrystals/minefactoryreloaded/net/CommonProxy.java
+++ b/src/powercrystals/minefactoryreloaded/net/CommonProxy.java
@@ -100,10 +100,13 @@ public class CommonProxy implements LoadingCallback
 				{
 					//{ spigot compat: force data array to exist
 					NibbleArray a = storage[i].getSkylightArray();
-					a.set(0, 0, 0, 0);
-					a.set(0, 0, 0, 15);
-					//}
-					Arrays.fill(a.getData(), (byte)0);
+					if(a != null)
+					{
+						a.set(0, 0, 0, 0);
+						a.set(0, 0, 0, 15);
+						//}
+						Arrays.fill(a.getData(), (byte)0);
+					}
 				}
 			chunk.resetRelightChecks();
 			chunk.setModified(true);


### PR DESCRIPTION

This fixes crashes with dimensions without skylight.

In my case Extra Utilities 2's  Quantum Quarry caused periodic crashes.
EU2's Quantum Quarry uses a pseudo dimension to fire the worldgen in order to generate the resources it mine's.
This Dimension seems to have no skylight (i assume it also tries to prevent any other relight event's being fired for vanilla code in order to reduce load).

After checking Minecraft's ExtendedBlockStorage class i noticed the Constructor has an argument for creating it without having the skylightarray being initialized, in this case getSkylightArray() will just return null.


Related Stacktrace
```
java.lang.NullPointerException: Ticking block entity
    at powercrystals.minefactoryreloaded.net.CommonProxy.relightChunk(CommonProxy.java:103)
    at powercrystals.minefactoryreloaded.world.WorldGenMassiveTree.func_180709_b(WorldGenMassiveTree.java:572)
    at powercrystals.minefactoryreloaded.world.MineFactoryReloadedWorldGen.generateMegaRubberTree(MineFactoryReloadedWorldGen.java:32)
    at powercrystals.minefactoryreloaded.world.MineFactoryReloadedWorldGen.generateFeature(MineFactoryReloadedWorldGen.java:83)
    at cofh.core.world.WorldHandler.generateWorld(WorldHandler.java:281)
    at cofh.core.world.WorldHandler.generate(WorldHandler.java:240)
    at net.minecraftforge.fml.common.registry.GameRegistry.generateWorld(GameRegistry.java:120)
    at com.rwtema.extrautils2.dimensions.workhousedim.WorldProviderSpecialDim.generate(WorldProviderSpecialDim.java:400)
    at com.rwtema.extrautils2.dimensions.workhousedim.WorldProviderSpecialDim.prepareNewChunk(WorldProviderSpecialDim.java:271)
    at com.rwtema.extrautils2.quarry.TileQuarry.getNextChunk(TileQuarry.java:428)
    at com.rwtema.extrautils2.quarry.TileQuarry.getNewChunk(TileQuarry.java:420)
    at com.rwtema.extrautils2.quarry.TileQuarry.advance(TileQuarry.java:409)
    at com.rwtema.extrautils2.quarry.TileQuarry.func_73660_a(TileQuarry.java:307)
    at net.minecraft.world.World.func_72939_s(World.java:1804)
    at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:620)
    at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:709)
    at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:387)
    at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:613)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:471)
    at java.lang.Thread.run(Thread.java:748)


-- Block entity being ticked --
Details:
    Name: XU2:TileQuarry // com.rwtema.extrautils2.quarry.TileQuarry
    Block type: ID #2106 (tile.extrautils2:quarry // com.rwtema.extrautils2.quarry.BlockQuarry)
    Block data value: 0 / 0x0 / 0b0000
    Block location: World: (542,72,321), Chunk: (at 14,4,1 in 33,20; contains blocks 528,0,320 to 543,255,335), Region: (1,0; contains chunks 32,0 to 63,31, blocks 512,0,0 to 1023,255,511)
    Actual block type: ID #2106 (tile.extrautils2:quarry // com.rwtema.extrautils2.quarry.BlockQuarry)
    Actual block data value: 0 / 0x0 / 0b0000
Stacktrace:
    at net.minecraft.world.World.func_72939_s(World.java:1804)
    at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:620)
```