### PR TITLE
Agricraft compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,20 @@ repositories {
         name = "Player's Maven"
         url = "http://maven.ic2.player.to/"
     }
-    maven { url "http://dvs1.progwml6.com/files/maven" }
+    maven {
+        name = "Progwml6's Maven"
+        url = "http://dvs1.progwml6.com/files/maven"
+    }
+    ivy {
+        name "Agricraft"
+        ivyPattern 'http://www.google.com/FAKE_URL/ugly_workaround_because_curseforge_403.txt'
+        artifactPattern "http://media.forgecdn.net/files/${agricraft_cf}/[module]-[revision].[ext]"
+    }
+    ivy {
+        name "InfinityLib"
+        ivyPattern 'http://www.google.com/FAKE_URL/ugly_workaround_because_curseforge_403.txt'
+        artifactPattern "http://media.forgecdn.net/files/${infinitylib_cf}/[module]-[revision].[ext]"
+    }
 }
 
 dependencies {
@@ -44,7 +57,8 @@ dependencies {
     compile "cofh:CoFHCore:${mc_version}-${cofhcore_version}:deobf"
     compile "net.industrial-craft:industrialcraft-2:${ic2_version}"
     compile "net.sengir.forestry:forestry_${mc_version}:${forestry_version}"
-    //deobfCompile "mezz.jei:jei_${mc_version}:${jei_version}"
+    deobfCompile "com.infinityraider:agricraft:${agricraft_version}"
+    deobfCompile "com.infinityraider:infinitylib:${infinitylib_version}"
 }
 
 sourceCompatibility = 1.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,7 @@ ccl_version = 2.5.9.+
 ic2_version = 2.6.149-ex110
 forestry_version = 5.1.10.192
 jei_version = 3.13.6.387
+agricraft_cf=2495/110
+agricraft_version=2.0.0-0.11.0-a21
+infinitylib_cf=2451/336
+infinitylib_version=0.11.0

--- a/src/powercrystals/minefactoryreloaded/MineFactoryReloadedCore.java
+++ b/src/powercrystals/minefactoryreloaded/MineFactoryReloadedCore.java
@@ -1,6 +1,7 @@
 package powercrystals.minefactoryreloaded;
 
 //this import brought to you by the department of redundancies department, the department that brought you this import
+
 import codechicken.lib.CodeChickenLib;
 import cofh.CoFHCore;
 import cofh.core.world.WorldHandler;
@@ -22,10 +23,16 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.CustomProperty;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.SidedProxy;
-import net.minecraftforge.fml.common.event.*;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
 import net.minecraftforge.fml.common.event.FMLInterModComms.IMCEvent;
+import net.minecraftforge.fml.common.event.FMLLoadCompleteEvent;
+import net.minecraftforge.fml.common.event.FMLMissingMappingsEvent;
 import net.minecraftforge.fml.common.event.FMLMissingMappingsEvent.MissingMapping;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.event.FMLModIdMappingEvent;
+import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 import net.minecraftforge.fml.common.registry.GameRegistry;
@@ -33,11 +40,18 @@ import net.minecraftforge.fml.common.registry.VillagerRegistry;
 import org.apache.logging.log4j.Logger;
 import powercrystals.minefactoryreloaded.farmables.MFRFarmables;
 import powercrystals.minefactoryreloaded.gui.MFRGUIHandler;
+import powercrystals.minefactoryreloaded.modhelpers.CompatRegistry;
 import powercrystals.minefactoryreloaded.net.CommonProxy;
 import powercrystals.minefactoryreloaded.net.EntityHandler;
 import powercrystals.minefactoryreloaded.net.GridTickHandler;
 import powercrystals.minefactoryreloaded.net.MFRPacket;
-import powercrystals.minefactoryreloaded.setup.*;
+import powercrystals.minefactoryreloaded.setup.BaseMod;
+import powercrystals.minefactoryreloaded.setup.BehaviorDispenseSafariNet;
+import powercrystals.minefactoryreloaded.setup.MFRConfig;
+import powercrystals.minefactoryreloaded.setup.MFRFluids;
+import powercrystals.minefactoryreloaded.setup.MFRLoot;
+import powercrystals.minefactoryreloaded.setup.MFRThings;
+import powercrystals.minefactoryreloaded.setup.MineFactoryReloadedFuelHandler;
 import powercrystals.minefactoryreloaded.setup.recipe.EnderIO;
 import powercrystals.minefactoryreloaded.setup.recipe.Vanilla;
 import powercrystals.minefactoryreloaded.setup.village.VillageCreationHandler;
@@ -248,6 +262,8 @@ public class MineFactoryReloadedCore extends BaseMod {
 
 	@EventHandler
 	public void postInit(FMLPostInitializationEvent evt) {
+
+		CompatRegistry.init();
 
 		TileEntityUnifier.updateUnifierLiquids();
 

--- a/src/powercrystals/minefactoryreloaded/modhelpers/CompatRegistry.java
+++ b/src/powercrystals/minefactoryreloaded/modhelpers/CompatRegistry.java
@@ -1,0 +1,25 @@
+package powercrystals.minefactoryreloaded.modhelpers;
+
+import com.google.common.collect.Sets;
+import net.minecraftforge.fml.common.Loader;
+import powercrystals.minefactoryreloaded.modhelpers.agricraft.Agricraft;
+
+import java.util.Set;
+
+public class CompatRegistry {
+
+	private static final Set<ICompat> compats = Sets.newHashSet();
+
+	static {
+		compats.add(Agricraft.INSTANCE);
+	}
+
+	public static void init() {
+
+		for (ICompat compat : compats) {
+			if (Loader.isModLoaded(compat.getModId())) {
+				compat.init();
+			}
+		}
+	}
+}

--- a/src/powercrystals/minefactoryreloaded/modhelpers/ICompat.java
+++ b/src/powercrystals/minefactoryreloaded/modhelpers/ICompat.java
@@ -1,0 +1,7 @@
+package powercrystals.minefactoryreloaded.modhelpers;
+
+public interface ICompat {
+
+	void init();
+	String getModId();
+}

--- a/src/powercrystals/minefactoryreloaded/modhelpers/agricraft/Agricraft.java
+++ b/src/powercrystals/minefactoryreloaded/modhelpers/agricraft/Agricraft.java
@@ -1,0 +1,25 @@
+package powercrystals.minefactoryreloaded.modhelpers.agricraft;
+
+import powercrystals.minefactoryreloaded.MFRRegistry;
+import powercrystals.minefactoryreloaded.modhelpers.ICompat;
+
+public class Agricraft implements ICompat {
+
+	public static final Agricraft INSTANCE = new Agricraft();
+
+	private Agricraft() {}
+
+	@Override
+	public void init() {
+
+		AgricraftCrop crop = new AgricraftCrop();
+		MFRRegistry.registerHarvestable(crop);
+		MFRRegistry.registerFertilizable(crop);
+	}
+
+	@Override
+	public String getModId() {
+
+		return "agricraft";
+	}
+}

--- a/src/powercrystals/minefactoryreloaded/modhelpers/agricraft/AgricraftCrop.java
+++ b/src/powercrystals/minefactoryreloaded/modhelpers/agricraft/AgricraftCrop.java
@@ -1,0 +1,112 @@
+package powercrystals.minefactoryreloaded.modhelpers.agricraft;
+
+import com.google.common.collect.Lists;
+import com.infinityraider.agricraft.api.v1.util.MethodResult;
+import com.infinityraider.agricraft.compat.vanilla.BonemealWrapper;
+import com.infinityraider.agricraft.init.AgriBlocks;
+import com.infinityraider.agricraft.tiles.TileEntityCrop;
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import powercrystals.minefactoryreloaded.api.FertilizerType;
+import powercrystals.minefactoryreloaded.api.HarvestType;
+import powercrystals.minefactoryreloaded.api.IFactoryFertilizable;
+import powercrystals.minefactoryreloaded.api.IFactoryHarvestable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+public class AgricraftCrop implements IFactoryHarvestable, IFactoryFertilizable {
+
+	@Override
+	public Block getPlant() {
+
+		return AgriBlocks.getInstance().CROP;
+	}
+
+	@Override
+	public boolean canFertilize(World world, BlockPos pos, FertilizerType fertilizerType) {
+
+		if (fertilizerType != FertilizerType.GrowPlant && fertilizerType != FertilizerType.Grass) {
+			return false;
+		}
+
+		TileEntity te = world.getTileEntity(pos);
+		if (te instanceof TileEntityCrop) {
+			return ((TileEntityCrop) te).acceptsFertilizer(BonemealWrapper.INSTANCE);
+		}
+		return false;
+	}
+
+	@Override
+	public boolean fertilize(World world, Random rand, BlockPos pos, FertilizerType fertilizerType) {
+
+		if (fertilizerType != FertilizerType.GrowPlant && fertilizerType != FertilizerType.Grass) {
+			return false;
+		}
+
+		TileEntity te = world.getTileEntity(pos);
+		if (te instanceof TileEntityCrop) {
+			return ((TileEntityCrop) te).onApplyFertilizer(BonemealWrapper.INSTANCE, rand) == MethodResult.SUCCESS;
+		}
+		return false;
+	}
+
+	@Override
+	public HarvestType getHarvestType() {
+
+		return HarvestType.Normal;
+	}
+
+	@Override
+	public boolean breakBlock() {
+
+		return false;
+	}
+
+	@Override
+	public boolean canBeHarvested(World world, Map<String, Boolean> harvesterSettings, BlockPos pos) {
+
+		TileEntity te = world.getTileEntity(pos);
+		if (te instanceof TileEntityCrop) {
+			return ((TileEntityCrop) te).canBeHarvested();
+		}
+		return false;
+	}
+
+	@Override
+	public List<ItemStack> getDrops(World world, Random rand, Map<String, Boolean> harvesterSettings, BlockPos pos) {
+
+		TileEntity te = world.getTileEntity(pos);
+		List<ItemStack> drops = Lists.newArrayList();
+		if (te instanceof TileEntityCrop) {
+			TileEntityCrop crop = (TileEntityCrop) te;
+			crop.getDrops(drops::add, false, false);
+
+			//add the bonus chance seeds
+			if (crop.getSeed().getPlant().getSeedDropChanceBonus() > rand.nextDouble()) {
+				drops.add(crop.getSeed().toStack());
+			}
+		}
+
+		return drops;
+	}
+
+	@Override
+	public void preHarvest(World world, BlockPos pos) {
+
+	}
+
+	@Override
+	public void postHarvest(World world, BlockPos pos) {
+
+		TileEntity te = world.getTileEntity(pos);
+		if (te instanceof TileEntityCrop) {
+			((TileEntityCrop) te).setGrowthStage(0);
+		}
+	}
+
+}


### PR DESCRIPTION
Adds compatibility to only harvest the crops from AC crop sticks and leaving sticks with planted seed in place.
Also adds compatibility for fertilizer to be able to fertilize basic seeds (the same ones that can be fertilized with bonemeal)

I had this coded and see people speaking about this from time to time so I can just PR it as well.